### PR TITLE
PHP 8.1 method_exists(): Argument #1 ($object_or_class) must be of ty…

### DIFF
--- a/src/helpers/SaveForm.php
+++ b/src/helpers/SaveForm.php
@@ -57,7 +57,7 @@ class SaveForm
             /*
              * get module base path
              */
-            if (method_exists($module, 'getBasePath')) {
+            if (!is_array($module) && method_exists($module, 'getBasePath')) {
                 $basePath = $module->getBasePath();
             } else {
                 if(!class_exists($module['class'])){


### PR DESCRIPTION
…pe object|string, array given

Error in PHP 8.1 method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given